### PR TITLE
Send personId instead of userId

### DIFF
--- a/src/pages/Patient/AppointmentChatbotPage/components/Chatbot/index.js
+++ b/src/pages/Patient/AppointmentChatbotPage/components/Chatbot/index.js
@@ -53,7 +53,7 @@ const Chatbot = () => {
             action = simpleUpdateIn(
                 action,
                 ['payload', 'activity', 'channelData', 'personId'],
-                () => user.userId
+                () => user.personId
             );
 
             action = simpleUpdateIn(


### PR DESCRIPTION
This solves the problem that the basic user cannot schedule an appointment for himself (as the account owner), instead scheduling it for another dependent.