### PR TITLE
Fixed a bug when the user's first or last name is null

### DIFF
--- a/src/components/NavBarDashboard/index.js
+++ b/src/components/NavBarDashboard/index.js
@@ -21,7 +21,9 @@ const NavBarDashboard = () => {
                 ):<></> }
                 <div className={styles.container_user_info}>
                     <div style={{'width':'100%'}}>
-                        <p className={styles.user_name}>{`${getLocalUser().names.split(' ')[0]} ${getLocalUser().lastNames.split(' ')[0]}`}</p>
+                        <p className={styles.user_name}>
+                            {`${getLocalUser().names?.split(' ')[0] ?? ''} ${getLocalUser().lastNames?.split(' ')[0] ?? ''}`}
+                        </p>
                         <p className={styles.user_role}>{ `(${getLocalUser().roles[getLocalUser().roles.length - 1]})`}</p>
                     </div>
                     <div className={styles.user}>


### PR DESCRIPTION
Fixed the following error:
```
Cannot read properties of null (reading 'split')
```
This error may occur because the first and last names are optional in the database (accept null values).