### PR TITLE
Removed inline-comments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,18 @@
 REACT_APP_API_URL=http://localhost:3978/api/
 REACT_APP_DIRECTLINE_URL=http://localhost:5000/
 REACT_APP_DIRECTLINE_WEB_SOCKET=0
-REACT_APP_MAX_DATE_IN_DATE_INPUT=60   #in days for scheduling
 REACT_APP_BUSINESS_NAME=World Dental
-REACT_APP_START_HOUR_OFFICE=09:00 #minimum office opening hours
-REACT_APP_END_HOUR_OFFICE=19:00 #maximum office hours of operation
-REACT_APP_START_HOUR_MORNING=09:00 #minimum start time for the morning shift for one employee
-REACT_APP_END_HOUR_MORNING=14:00 #maximum ending time for an employee's morning shift
-REACT_APP_START_HOUR_AFTERNOON=13:00 #minimum start time for an employee's afternoon shift
-REACT_APP_END_HOUR_AFTERNOON=19:00 #maximum ending time for an employee's afternoon shift
+# In days for scheduling
+REACT_APP_MAX_DATE_IN_DATE_INPUT=60
+# Minimum office opening hours
+REACT_APP_START_HOUR_OFFICE=09:00
+# Maximum office hours of operation
+REACT_APP_END_HOUR_OFFICE=19:00
+# Minimum start time for the morning shift for one employee
+REACT_APP_START_HOUR_MORNING=09:00
+# Maximum ending time for an employee's morning shift
+REACT_APP_END_HOUR_MORNING=14:00
+# Minimum start time for an employee's afternoon shift
+REACT_APP_START_HOUR_AFTERNOON=13:00
+# Maximum ending time for an employee's afternoon shift
+REACT_APP_END_HOUR_AFTERNOON=19:00


### PR DESCRIPTION
It seems that the dotenv package is not ignoring inline comments and this causes the *hours validation* to not behave as expected.